### PR TITLE
Whitelist Mosh for Chrome as a client.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,9 @@
   ],
   "externally_connectable": {
     "ids": [
-      "pnhechapfaindjhompbnflcldabbghjo"
+      "pnhechapfaindjhompbnflcldabbghjo",
+      "ooiklbnjmhbcgemelgfhaeaocllobloj",
+      "hmgggebkhjjkiimkjlknpdgapncghehh"
     ]
   }
 }


### PR DESCRIPTION
Add both stable (ooi...) and dev (hmg...) tracks of Mosh for Chrome.

Mosh for Chrome is whitelisted in gnubbyd, so it would be good to have it whitelisted here as well.