### PR TITLE
Detect encrypted OpenSSH keys so we properly prompt for a passphrase

### DIFF
--- a/go/keys/manager.go
+++ b/go/keys/manager.go
@@ -221,6 +221,15 @@ func (s *storedKey) Encrypted() bool {
 		return true
 	}
 
+	// OpenSSH keys don't have a type or header indicating if they are
+	// encrypted. We could parse the key to determine that, but that would
+	// reimplement the underlying crypto libraries. Instead, just attempt to
+	// decrypt it without a passphrase.
+	if block.Type == "OPENSSH PRIVATE KEY" {
+		_, err := ssh.ParseRawPrivateKey([]byte(s.PEMPrivateKey))
+		return err != nil
+	}
+
 	return strings.Contains(block.Headers["Proc-Type"], "ENCRYPTED")
 }
 


### PR DESCRIPTION
This should be the final part to supporting OpenSSH formatted keys in #7 