### PR TITLE
Support multiple key prefixes in the storage layer.

### DIFF
--- a/go/background/main.go
+++ b/go/background/main.go
@@ -55,6 +55,9 @@ func (a *background) Name() string {
 }
 
 func (a *background) Init(ctx jsutil.AsyncContext, cleanup *jsutil.CleanupFuncs) error {
+	jsutil.Log("Cleaning up old data")
+	a.manager.CleanupOldData(ctx)
+
 	jsutil.Log("Loading keys from session")
 	if err := a.manager.LoadFromSession(ctx); err != nil {
 		jsutil.LogError("failed to load keys into agent: %v", err)

--- a/go/keys/manager.go
+++ b/go/keys/manager.go
@@ -139,8 +139,8 @@ type Manager interface {
 func NewManager(agt agent.Agent, syncStorage, sessionStorage storage.Area) *DefaultManager {
 	return &DefaultManager{
 		agent:       agt,
-		storedKeys:  storage.NewTyped[storedKey](syncStorage, keyPrefix),
-		sessionKeys: storage.NewTyped[sessionKey](sessionStorage, keyPrefix),
+		storedKeys:  storage.NewTyped[storedKey](syncStorage, storedKeyPrefixes),
+		sessionKeys: storage.NewTyped[sessionKey](sessionStorage, sessionKeyPrefixes),
 	}
 }
 
@@ -216,9 +216,15 @@ type sessionKey struct {
 	PrivateKey string `js:"privateKey"`
 }
 
+var (
+	// storedKeyPrefix is the prefix for keys stored in persistent storage.
+	storedKeyPrefixes = []string{"key"}
+	// sessionKeyPrefix is the prefix for key material stored in-memory
+	// for our current session.
+	sessionKeyPrefixes = []string{"key"}
+)
+
 const (
-	// keyPrefix is the prefix for keys stored in persistent storage.
-	keyPrefix = "key"
 	// commentPrefix is the prefix for the comment included when a
 	// configured key is loaded into the agent. The full comment is of the
 	// form 'chrome-ssh-agent:<id>'.

--- a/go/keys/manager.go
+++ b/go/keys/manager.go
@@ -138,17 +138,21 @@ type Manager interface {
 // supplied agent, and store configured keys in the supplied storage.
 func NewManager(agt agent.Agent, syncStorage, sessionStorage storage.Area) *DefaultManager {
 	return &DefaultManager{
-		agent:       agt,
-		storedKeys:  storage.NewTyped[storedKey](syncStorage, storedKeyPrefixes),
-		sessionKeys: storage.NewTyped[sessionKey](sessionStorage, sessionKeyPrefixes),
+		agent:          agt,
+		syncStorage:    syncStorage,
+		sessionStorage: sessionStorage,
+		storedKeys:     storage.NewTyped[storedKey](syncStorage, storedKeyPrefixes),
+		sessionKeys:    storage.NewTyped[sessionKey](sessionStorage, sessionKeyPrefixes),
 	}
 }
 
 // DefaultManager is an implementation of Manager.
 type DefaultManager struct {
-	agent       agent.Agent
-	storedKeys  *storage.Typed[storedKey]
-	sessionKeys *storage.Typed[sessionKey]
+	agent          agent.Agent
+	syncStorage    storage.Area
+	sessionStorage storage.Area
+	storedKeys     *storage.Typed[storedKey]
+	sessionKeys    *storage.Typed[sessionKey]
 }
 
 // storedKey is the raw object stored in persistent storage for a configured
@@ -222,6 +226,36 @@ var (
 	// sessionKeyPrefix is the prefix for key material stored in-memory
 	// for our current session.
 	sessionKeyPrefixes = []string{"key"}
+
+	// oldStoredKeyPrefixes are the prefixes for stored keys that we
+	// previously used which are safe to delete from storage.
+	//
+	// WARNING: Only add a prefix to this list *after* the following
+	// sequence of events:
+	// (a) A replacement prefix has been added to the storedKeyPrefixes.
+	// (b) Release including (a) has been deployed for 3 months.
+	//     NOTE: At this point, we should be writing data to the new prefix
+	//     and should be assured that data for both prefixes is equivalent.
+	// (c) The old prefix has been removed from the above list.
+	// (d) Release including (b) has been deployed for at least 3 weeks
+	//     without any reported issues of data loss.
+	//     NOTE: At this point, it is safe to add the prefix back to
+	//     storedKeyPrefixes; the data is present, but we just aren't
+	//     reading it.
+	//
+	// This sequence of events is important to support rollbacks without
+	// incorrectly deleting data.
+	//
+	// For tracking, comments should track the progression of these events
+	// for each prefix slated for deletion.
+	oldStoredKeyPrefixes = []string{}
+
+	// oldSessionKeyPrefixes are the prefixes for session key material
+	// that are safe to delete from storage.
+	//
+	// WARNING: See warning for oldStoredKeyPrefixes above; the same applies
+	// here.
+	oldSessionKeyPrefixes = []string{}
 )
 
 const (
@@ -304,6 +338,27 @@ var (
 	errParseFailed   = errors.New("key parse failed")
 	errMarshalFailed = errors.New("key marshalling failed")
 )
+
+// CleanupOldData removes storage data that is no longer required.
+func (m *DefaultManager) CleanupOldData(ctx jsutil.AsyncContext) {
+	jsutil.LogDebug("DefaultManager.CleanupOldData: Cleaning up stored keys")
+
+	areas := []storage.Area{
+		m.syncStorage,
+		m.sessionStorage,
+	}
+	prefixesLists := [][]string{
+		oldStoredKeyPrefixes,
+		oldSessionKeyPrefixes,
+	}
+	for _, area := range areas {
+		for _, prefixes := range prefixesLists {
+			if err := storage.DeleteViewPrefixes(ctx, prefixes, area); err != nil {
+				jsutil.LogError("failed to delete old prefixes '%s': %v", oldStoredKeyPrefixes, err)
+			}
+		}
+	}
+}
 
 // LoadFromSession loads all keys for the current session into the agent.
 func (m *DefaultManager) LoadFromSession(ctx jsutil.AsyncContext) error {

--- a/go/storage/typed.go
+++ b/go/storage/typed.go
@@ -36,8 +36,8 @@ type Typed[V any] struct {
 
 // NewTyped returns a new Typed using the underlying persistent store.
 // keyPrefix is the prefix used to distinguish values from others in the same
-// underlying store.
-func NewTyped[V any](store Area, keyPrefix string) *Typed[V] {
+// underlying store; multiple may be supplied to support migration scenarios.
+func NewTyped[V any](store Area, keyPrefix []string) *Typed[V] {
 	return &Typed[V]{
 		store: NewView(keyPrefix, store),
 	}

--- a/go/storage/typed_test.go
+++ b/go/storage/typed_test.go
@@ -35,6 +35,8 @@ var (
 
 const testKeyPrefix = "key"
 
+var testKeyPrefixes = []string{testKeyPrefix}
+
 func TestTypedReadAll(t *testing.T) {
 	testcases := []struct {
 		description string
@@ -83,7 +85,7 @@ func TestTypedReadAll(t *testing.T) {
 					t.Fatalf("Set failed: %v", err)
 				}
 
-				ts := NewTyped[myStruct](store, testKeyPrefix)
+				ts := NewTyped[myStruct](store, testKeyPrefixes)
 
 				got, err := ts.ReadAll(ctx)
 				if diff := cmp.Diff(got, tc.want, cmpopts.SortSlices(myStructLess)); diff != "" {
@@ -133,7 +135,7 @@ func TestTypedRead(t *testing.T) {
 					t.Fatalf("Set failed: %v", err)
 				}
 
-				ts := NewTyped[myStruct](store, testKeyPrefix)
+				ts := NewTyped[myStruct](store, testKeyPrefixes)
 
 				got, err := ts.Read(ctx, tc.test)
 				if diff := cmp.Diff(got, tc.want); diff != "" {
@@ -191,7 +193,7 @@ func TestTypedWrite(t *testing.T) {
 					t.Fatalf("Set failed: %v", err)
 				}
 
-				ts := NewTyped[myStruct](store, testKeyPrefix)
+				ts := NewTyped[myStruct](store, testKeyPrefixes)
 
 				err := ts.Write(ctx, tc.write)
 				if diff := cmp.Diff(err, tc.wantErr, cmpopts.EquateErrors()); diff != "" {
@@ -251,7 +253,7 @@ func TestTypedDelete(t *testing.T) {
 					t.Fatalf("Set failed: %v", err)
 				}
 
-				ts := NewTyped[myStruct](store, testKeyPrefix)
+				ts := NewTyped[myStruct](store, testKeyPrefixes)
 
 				err := ts.Delete(ctx, tc.test)
 				if diff := cmp.Diff(err, tc.wantErr, cmpopts.EquateErrors()); diff != "" {

--- a/go/storage/view.go
+++ b/go/storage/view.go
@@ -17,6 +17,7 @@
 package storage
 
 import (
+	"fmt"
 	"strings"
 	"syscall/js"
 
@@ -29,36 +30,56 @@ import (
 //
 // It is the caller's responsibility to supply unique key prefixes as required.
 type View struct {
-	// prefix is the prefix prepended to each key. The prefix disambiguates
+	// prefixes are the prefix prepended to each key. The prefix disambiguates
 	// entries for this view from entries for a different view.
-	prefix string
+	//
+	// When there is more than one prefix, we always apply an operation to
+	// each prefix. This helps support migration of data between prefixes:
+	//   Step 0: Read/write data under only the old prefix.
+	//   Step 1: Read/write data under old and new prefixes. This supports
+	//     older and newer versions concurrently.
+	//   [let sufficient time pass for older version to go away]
+	//   Step 2: Read/write data under new prefix.
+	//   Step 3: Delete data under old prefix to free up space.
+	//
+	// Prefixes are in preference order. That is, when reading, if a key is
+	// present under multiple prefixes, the first-appearing prefix in this
+	// list takes precedence.
+	prefixes []string
 
 	// s is the underlying storage area.
 	s Area
 }
 
-// NewView returns a view of a storage area with a given key prefix.
-func NewView(prefix string, store Area) *View {
+// NewView returns a view of a storage area with a given set of key prefixes.
+func NewView(prefixes []string, store Area) *View {
+	var prefixesAdj []string
+	for _, p := range prefixes {
+		prefixesAdj = append(prefixesAdj, p+".")
+	}
+
 	return &View{
-		prefix: prefix + ".",
-		s:      store,
+		prefixes: prefixesAdj,
+		s:        store,
 	}
 }
 
-// isViewKey detects if the key belongs to our view.
-func (v *View) readKey(key string) (string, bool) {
-	return strings.TrimPrefix(key, v.prefix), strings.HasPrefix(key, v.prefix)
+// readKey detects if the key belongs to our view.
+func (v *View) readKey(prefix, key string) (string, bool) {
+	return strings.TrimPrefix(key, prefix), strings.HasPrefix(key, prefix)
 }
 
-func (v *View) makeKey(key string) string {
-	return v.prefix + key
+func (v *View) makeKey(prefix, key string) string {
+	return prefix + key
 }
 
 // Set implements Area.Set().
 func (v *View) Set(ctx jsutil.AsyncContext, data map[string]js.Value) error {
 	ndata := map[string]js.Value{}
 	for k, val := range data {
-		ndata[v.makeKey(k)] = val
+		for _, prefix := range v.prefixes {
+			ndata[v.makeKey(prefix, k)] = val
+		}
 	}
 	return v.s.Set(ctx, ndata)
 }
@@ -72,8 +93,16 @@ func (v *View) Get(ctx jsutil.AsyncContext) (map[string]js.Value, error) {
 
 	ndata := map[string]js.Value{}
 	for k, val := range data {
-		if sk, ok := v.readKey(k); ok {
-			ndata[sk] = val
+		for _, prefix := range v.prefixes {
+			sk, ok := v.readKey(prefix, k)
+			if !ok {
+				continue
+			}
+
+			if _, present := ndata[sk]; !present {
+				ndata[sk] = val
+				continue // First takes precedence; stop.
+			}
 		}
 	}
 	return ndata, nil
@@ -83,7 +112,31 @@ func (v *View) Get(ctx jsutil.AsyncContext) (map[string]js.Value, error) {
 func (v *View) Delete(ctx jsutil.AsyncContext, keys []string) error {
 	var nkeys []string
 	for _, k := range keys {
-		nkeys = append(nkeys, v.makeKey(k))
+		for _, prefix := range v.prefixes {
+			nkeys = append(nkeys, v.makeKey(prefix, k))
+		}
 	}
 	return v.s.Delete(ctx, nkeys)
+}
+
+// DeleteViewPrefixes deletes all storage entries for views with the given prefixes.
+func DeleteViewPrefixes(ctx jsutil.AsyncContext, prefixes []string, store Area) error {
+	v := NewView(prefixes, store)
+
+	// Gather all of the keys.
+	data, err := v.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get keys: %v", err)
+	}
+	var keys []string
+	for k := range data {
+		keys = append(keys, k)
+	}
+
+	// Remove them all.
+	if err := v.Delete(ctx, keys); err != nil {
+		return fmt.Errorf("failed to delete keys: %v", err)
+	}
+
+	return nil
 }

--- a/go/storage/view.go
+++ b/go/storage/view.go
@@ -92,16 +92,16 @@ func (v *View) Get(ctx jsutil.AsyncContext) (map[string]js.Value, error) {
 	}
 
 	ndata := map[string]js.Value{}
-	for k, val := range data {
-		for _, prefix := range v.prefixes {
+	for _, prefix := range v.prefixes {
+		for k, val := range data {
 			sk, ok := v.readKey(prefix, k)
 			if !ok {
 				continue
 			}
 
+			// Don't overwrite; first prefix takes precedence.
 			if _, present := ndata[sk]; !present {
 				ndata[sk] = val
-				continue // First takes precedence; stop.
 			}
 		}
 	}

--- a/go/storage/view_test.go
+++ b/go/storage/view_test.go
@@ -392,7 +392,6 @@ func TestDeleteViewPrefixes(t *testing.T) {
 				"bar.some-key":  "4",
 			},
 		},
-
 	}
 
 	for _, tc := range testcases {

--- a/go/storage/view_test.go
+++ b/go/storage/view_test.go
@@ -378,6 +378,21 @@ func TestDeleteViewPrefixes(t *testing.T) {
 			},
 			wantRaw: map[string]string{},
 		},
+		{
+			description: "no prefixes",
+			prefixes:    []string{},
+			initRaw: map[string]js.Value{
+				"foo.my-key":    js.ValueOf(2),
+				"foo.other-key": js.ValueOf("some-val"),
+				"bar.some-key":  js.ValueOf(4),
+			},
+			wantRaw: map[string]string{
+				"foo.my-key":    "2",
+				"foo.other-key": `"some-val"`,
+				"bar.some-key":  "4",
+			},
+		},
+
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
Support multiple key prefixes in the storage layer. This allows us to migrate to different key prefixes over time.