### PR TITLE
Fix rules_pkg hash

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,7 +47,7 @@ http_archive(
 
 http_archive(
     name = "rules_pkg",
-    sha256 = "bcc96ae58d9d61db1a36a13d29e85dc2c1696ecb7997f9a26643ab0971ecb2ef",
+    sha256 = "335632735e625d408870ec3e361e192e99ef7462315caa887417f4d88c4c8fb8",
     urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.9.0/rules_pkg-0.9.0.tar.gz"],
 )
 


### PR DESCRIPTION
Hash was corrected; see https://github.com/bazelbuild/rules_pkg/issues/694.