### PR TITLE
Install bazel via homebrew.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,14 +10,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         python \
         git
 
-# Install Bazel
-ARG BAZELISK_VERSION=v1.10.1
-ARG BAZELISK_DOWNLOAD_SHA=dev-mode
-RUN curl -fSsL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-amd64 \
-    && ([ "${BAZELISK_DOWNLOAD_SHA}" = "dev-mode" ] || echo "${BAZELISK_DOWNLOAD_SHA} */usr/local/bin/bazelisk" | sha256sum --check - ) \
-    && chmod 0755 /usr/local/bin/bazelisk \
-    && ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
-
 # Install Homebrew. See:
 #   https://docs.brew.sh/Installation#skip-tap-cloning-beta
 #   https://docs.brew.sh/Installation#unattended-installation
@@ -28,6 +20,10 @@ RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/instal
     && chmod 0755 /etc/profile.d/99-homebrew.sh \
     && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" \
     && brew --version
+
+# Install Bazel
+RUN eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" \
+    && brew install bazelisk
 
 # Install pnpm package manager
 RUN eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" \


### PR DESCRIPTION
This avoids need for hardcoding versions in Dockerfile