### PR TITLE
Properly detect Chrome version scheme.

### DIFF
--- a/build_defs/chromium.bzl
+++ b/build_defs/chromium.bzl
@@ -1,6 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-_CHROME_VERSION = "122.0.6210.0"  # renovate: datasource=custom.chrome depName=linux64 versioning=semver-coerced
+_CHROME_VERSION = "121.0.6100.0"  # renovate: datasource=custom.chrome depName=linux64 versioning=loose
 
 def chromium_data_dependencies():
     http_archive(


### PR DESCRIPTION
The 'loose' scheme is required to detect the build component of the version.

Also, demote the Chrome version to see if renovate will update it.