### PR TITLE
Rename custom datasource to chrome-for-testing.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,7 +21,7 @@
     }
   ],
   "customDatasources": {
-    "chrome": {
+    "chrome-for-testing": {
       "defaultRegistryUrlTemplate": "https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json",
       "transformTemplates": [
         "{ 'releases': versions[$count(downloads.'{{depName}}') > 0].{ 'version': version } }"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -66,6 +66,6 @@ use_repo(rules_ts_ext, "npm_typescript")
 # Pull in Chrome for use in tests
 chrome = use_extension("//build_defs/chrome:extension.bzl", "chrome")
 chrome.download(
-    version = "122.0.6217.0",  # renovate: datasource=custom.chrome depName=chrome versioning=loose
+    version = "122.0.6212.0",  # renovate: datasource=custom.chrome-for-testing depName=chrome versioning=loose
 )
 use_repo(chrome, "chrome_chrome_linux64")


### PR DESCRIPTION
Allows datasource and dependency name to be different.